### PR TITLE
Use GNU Octave instead of Matlab to run (a modified) FANN-GO

### DIFF
--- a/code/pipeline/run_fanngo.py
+++ b/code/pipeline/run_fanngo.py
@@ -33,7 +33,8 @@ def run_fanngo(config):
         else:
             print >>run_file, line
     run_file.close()
-    cmd = ["/matlab/bin/matlab", "-nojvm", "-nodisplay", "-nosplash"]
+    cmd = ["octave", "--norc", "--no-window-system", "--quiet"]
     print(" ".join(cmd))
+    os.environ["NPROC"] = str(config["input"]["cpus"]);
     check_output_and_run(out_score,cmd,run_file_path)
 


### PR DESCRIPTION
Not all environments have Matlab; with a few tweaks, FANN-GO can use Octave.

Also requires the attached patch to the version of FANN-GO that is distributed with GOMAP-data:

[fanngo.patch.txt](https://github.com/Dill-PICL/GOMAP/files/2860978/fanngo.patch.txt)

Specifically:

* Replace Matlab-only readfasta with this GPLv3 substitute:
    https://raw.githubusercontent.com/EESI/quikr/master/src/matlab/fastaread.m
* Replace Matlab-only cell2table with a for loop & some fprintf()s
* Instead of hard-coding blastp to use 16 threads, use the number of CPUs specified in the GOMAP config file (by setting an environment variable (NPROC) that is now read in make_sequences.m)
* Use blastp in PATH (i.e., blastp baked into the Singularity image) rather than bundled with FANN-GO in GOMAP-data
* Allow FANN-GO to be installed on a read-only file system (e.g., in a Singularity image):
  - Output of blastp is read from pipe, obviating the need for a temporary file to contain the blast output
  - FANN-GO temp/ directory isn't used; rather, filenames of temporary files are generated using the built-in tempname() function
